### PR TITLE
Replace chrono with time, take 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,14 @@ include = ["Cargo.toml", "README.md", "src/*.rs", "LICENSE"]
 readme = "README.md"
 
 [dependencies]
-chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 http = "0.2.6"
-http-serde = { version = "1.0.3", optional = true }
-serde = { version = "1.0.133", optional = true, features = ["derive"] }
-reqwest = { version = "0.11.8", default-features = false, optional = true }
+http-serde = { version = "1.1.0", optional = true }
+serde = { version = "1.0.136", optional = true, features = ["derive"] }
+reqwest = { version = "0.11.9", default-features = false, optional = true }
+time = { version = "0.3.7", features = ["parsing", "formatting"] }
 
 [dev-dependencies]
-chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
-serde_json = "1.0.74"
+serde_json = "1.0.78"
 
 [features]
 default = ["with_serde"]

--- a/tests/okhttp.rs
+++ b/tests/okhttp.rs
@@ -1,7 +1,8 @@
-use chrono::{DateTime, Utc};
 use http::{header, HeaderValue, Request, Response};
 use http_cache_semantics::CacheOptions;
 use http_cache_semantics::CachePolicy;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc2822;
 use std::time::SystemTime;
 
 fn request_parts(builder: http::request::Builder) -> http::request::Parts {
@@ -464,14 +465,11 @@ fn test_do_not_cache_partial_response() {
 }
 
 fn format_date(delta: i64, unit: i64) -> String {
-    let now: DateTime<Utc> = Utc::now();
-    let timestamp = now.timestamp() + delta * unit;
+    let now = OffsetDateTime::now_utc();
+    let timestamp = now.unix_timestamp() + delta * unit;
 
-    let date = DateTime::<Utc>::from_utc(
-        chrono::NaiveDateTime::from_timestamp(timestamp as _, 0),
-        Utc,
-    );
-    date.to_rfc2822()
+    let date = OffsetDateTime::from_unix_timestamp(timestamp).unwrap();
+    date.format(&Rfc2822).unwrap()
 }
 
 fn get_cached_response(

--- a/tests/responsetest.rs
+++ b/tests/responsetest.rs
@@ -1,6 +1,7 @@
-use chrono::prelude::*;
 use http::*;
 use http_cache_semantics::*;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc2822;
 use std::time::Duration;
 use std::time::SystemTime;
 
@@ -675,8 +676,8 @@ fn date_str(now: SystemTime) -> String {
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
         .as_secs();
-    let date = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(timestamp as _, 0), Utc);
-    date.to_rfc2822()
+    let date = OffsetDateTime::from_unix_timestamp(timestamp as i64).unwrap();
+    date.format(&Rfc2822).unwrap()
 }
 
 fn get_cached_response(

--- a/tests/satisfy.rs
+++ b/tests/satisfy.rs
@@ -1,8 +1,9 @@
-use chrono::offset::Utc;
-use chrono::Duration;
+use time::Duration;
 use http::{header, Method, Request, Response};
 use http_cache_semantics::CacheOptions;
 use http_cache_semantics::CachePolicy;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc2822;
 use std::time::SystemTime;
 
 fn request_parts(builder: http::request::Builder) -> http::request::Parts {
@@ -32,10 +33,11 @@ fn test_when_urls_match() {
 #[test]
 fn test_when_expires_is_present() {
     let now = SystemTime::now();
-    let two_seconds_later = Utc::now()
-        .checked_add_signed(Duration::seconds(2))
+    let two_seconds_later = OffsetDateTime::now_utc()
+        .checked_add(Duration::seconds(2))
         .unwrap()
-        .to_rfc2822();
+        .format(&Rfc2822)
+        .unwrap();
     let response = &response_parts(
         Response::builder()
             .status(302)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,7 +2,6 @@
 //! cached response can be reused, following the rules specified in [RFC
 //! 7234](https://httpwg.org/specs/rfc7234.html).
 
-use chrono::prelude::*;
 use http::header::HeaderName;
 use http::header::HeaderValue;
 use http::Request;
@@ -10,6 +9,8 @@ use http::Response;
 use http_cache_semantics::*;
 use serde_json::json;
 use serde_json::Value;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc2822;
 use std::time::SystemTime;
 
 fn res(json: Value) -> Response<()> {
@@ -349,11 +350,11 @@ fn test_do_not_cache_partial_response() {
 }
 
 fn format_date(delta: i64, unit: i64) -> String {
-    let now: DateTime<Utc> = Utc::now();
-    let timestamp = now.timestamp() + delta * unit;
+    let now = OffsetDateTime::now_utc();
+    let timestamp = now.unix_timestamp() + delta * unit;
 
-    let date = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(timestamp as _, 0), Utc);
-    date.to_rfc2822()
+    let date = OffsetDateTime::from_unix_timestamp(timestamp).unwrap();
+    date.format(&Rfc2822).unwrap()
 }
 
 #[test]


### PR DESCRIPTION
A new release of time with the Rfc2822 format definition has been released. This PR updates the previous reverted one to make use of that, and updates the tests as well. Rebasing to the latest main was slightly tricky, so if there are any oddities in the diff I missed that's probably why.