### PR TITLE
Avoid using unneeded features of reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 http = "0.2.4"
 http-serde = { version = "1.0.2", optional = true }
 serde = { version = "1.0.130", optional = true, features = ["derive"] }
-reqwest = { version = "0.11.3", optional = true }
+reqwest = { version = "0.11.3", default-features = false, optional = true }
 
 [dev-dependencies]
 chrono = { version = "0.4.19", default-features = false, features = ["clock"] }


### PR DESCRIPTION
By not specifying `default-features = false` maybe unwanted features of the `reqwest` create will be enabled. In my case I want to disable the default tls implementation because it is not easily compatible with android.