### PR TITLE
Tweak `CachePolicy` construction

### DIFF
--- a/tests/okhttp.rs
+++ b/tests/okhttp.rs
@@ -448,6 +448,7 @@ fn test_get_headers_deletes_cached_100_level_warnings() {
                 .header("cache-control", "immutable")
                 .header(header::WARNING, "199 test danger, 200 ok ok"),
         ),
+        now,
     ).unwrap();
 
     assert_eq!(
@@ -467,6 +468,7 @@ fn test_do_not_cache_partial_response() {
                 .header(header::CONTENT_RANGE, "bytes 100-100/200")
                 .header(header::CACHE_CONTROL, "max-age=60"),
         ),
+        SystemTime::now(),
     ).unwrap_err();
 }
 

--- a/tests/request.rs
+++ b/tests/request.rs
@@ -29,6 +29,7 @@ fn test_no_store_kills_cache() {
                 .header(header::CACHE_CONTROL, "no-store"),
         ),
         &public_cacheable_response(),
+        now,
     ).unwrap_err().0;
 
     assert!(policy.is_stale(now));
@@ -40,6 +41,7 @@ fn test_post_not_cacheable_by_default() {
     let policy = CachePolicy::try_new(
         &request_parts(Request::builder().method(Method::POST)),
         &response_parts(Response::builder().header(header::CACHE_CONTROL, "public")),
+        now,
     ).unwrap_err().0;
 
     assert!(policy.is_stale(now));
@@ -51,6 +53,7 @@ fn test_post_cacheable_explicitly() {
     let policy = CachePolicy::try_new(
         &request_parts(Request::builder().method(Method::POST)),
         &public_cacheable_response(),
+        now,
     ).unwrap();
 
     assert!(!policy.is_stale(now));
@@ -66,6 +69,7 @@ fn test_public_cacheable_auth_is_ok() {
                 .header(header::AUTHORIZATION, "test"),
         ),
         &public_cacheable_response(),
+        now,
     ).unwrap();
 
     assert!(!policy.is_stale(now));
@@ -102,6 +106,7 @@ fn test_revalidate_auth_is_ok() {
         &response_parts(
             Response::builder().header(header::CACHE_CONTROL, "max-age=88,must-revalidate"),
         ),
+        SystemTime::now(),
     ).unwrap();
 
     assert!(policy.is_storable());
@@ -117,6 +122,7 @@ fn test_auth_prevents_caching_by_default() {
                 .header(header::AUTHORIZATION, "test"),
         ),
         &cacheable_response(),
+        now,
     ).unwrap_err().0;
 
     assert!(policy.is_stale(now));

--- a/tests/revalidate.rs
+++ b/tests/revalidate.rs
@@ -32,6 +32,7 @@ fn simple_request_with_etagged_response() -> CachePolicy {
     CachePolicy::try_new(
         &simple_request(),
         &response_parts(cacheable_response_builder().header(header::ETAG, etag_value())),
+        SystemTime::now(),
     ).unwrap()
 }
 
@@ -39,6 +40,7 @@ fn simple_request_with_cacheable_response() -> CachePolicy {
     CachePolicy::try_new(
         &simple_request(),
         &response_parts(cacheable_response_builder()),
+        SystemTime::now(),
     ).unwrap()
 }
 
@@ -46,6 +48,7 @@ fn simple_request_with_always_variable_response() -> CachePolicy {
     CachePolicy::try_new(
         &simple_request(),
         &response_parts(cacheable_response_builder().header(header::VARY, "*")),
+        SystemTime::now(),
     ).unwrap()
 }
 
@@ -197,6 +200,7 @@ fn test_skips_weak_validators_on_post() {
                 .header(header::LAST_MODIFIED, very_old_date())
                 .header(header::ETAG, etag_value()),
         ),
+        now,
     ).unwrap();
 
     let headers = get_revalidation_request(
@@ -226,6 +230,7 @@ fn test_skips_weak_validators_on_post_2() {
         &response_parts(
             cacheable_response_builder().header(header::LAST_MODIFIED, very_old_date()),
         ),
+        now,
     ).unwrap();
 
     let headers = get_revalidation_request(
@@ -254,6 +259,7 @@ fn test_merges_validators() {
                 .header(header::ETAG, etag_value())
                 .header(header::CACHE_CONTROL, "must-revalidate"),
         ),
+        now,
     ).unwrap();
 
     let headers = get_revalidation_request(
@@ -281,6 +287,7 @@ fn test_when_last_modified_validator_is_present() {
         &response_parts(
             cacheable_response_builder().header(header::LAST_MODIFIED, very_old_date()),
         ),
+        now,
     ).unwrap();
 
     let headers = get_revalidation_request(
@@ -330,7 +337,7 @@ fn test_113_added() {
             .header(header::LAST_MODIFIED, very_old_date()),
     );
     let req = simple_request();
-    let policy = CachePolicy::try_new(&req, &very_old_response).unwrap();
+    let policy = CachePolicy::try_new(&req, &very_old_response, now).unwrap();
 
     let headers = get_cached_response(&policy, &req, now).headers;
 
@@ -353,6 +360,7 @@ fn test_removes_warnings() {
                 .header("cache-control", "max-age=2")
                 .header(header::WARNING, "199 test danger"),
         ),
+        now,
     ).unwrap();
 
     assert!(!get_cached_response(&policy, &req, now)
@@ -370,6 +378,7 @@ fn test_must_contain_any_etag() {
                 .header(header::LAST_MODIFIED, very_old_date())
                 .header(header::ETAG, etag_value()),
         ),
+        now,
     ).unwrap();
 
     let headers = get_revalidation_request(
@@ -414,6 +423,7 @@ fn test_should_send_the_last_modified_value() {
                 .header(header::LAST_MODIFIED, very_old_date())
                 .header(header::ETAG, etag_value()),
         ),
+        now,
     ).unwrap();
 
     let headers = get_revalidation_request(
@@ -443,6 +453,7 @@ fn test_should_not_send_the_last_modified_value_for_post() {
         &response_parts(
             cacheable_response_builder().header(header::LAST_MODIFIED, very_old_date()),
         ),
+        now,
     ).unwrap();
 
     let headers = get_revalidation_request(
@@ -470,6 +481,7 @@ fn test_should_not_send_the_last_modified_value_for_range_request() {
         &response_parts(
             cacheable_response_builder().header(header::LAST_MODIFIED, very_old_date()),
         ),
+        now,
     ).unwrap();
 
     let headers = get_revalidation_request(

--- a/tests/satisfy.rs
+++ b/tests/satisfy.rs
@@ -23,7 +23,7 @@ fn test_when_urls_match() {
             .header(header::CACHE_CONTROL, "max-age=2"),
     );
 
-    let policy = CachePolicy::try_new(&request_parts(Request::builder().uri("/")), response)
+    let policy = CachePolicy::try_new(&request_parts(Request::builder().uri("/")), response, now)
         .unwrap();
 
     assert!(policy
@@ -45,7 +45,8 @@ fn test_when_expires_is_present() {
             .header(header::EXPIRES, two_seconds_later),
     );
 
-    let policy = CachePolicy::try_new(&request_parts(Request::builder()), response).unwrap();
+    let policy =
+        CachePolicy::try_new(&request_parts(Request::builder()), response, now).unwrap();
 
     assert!(policy
         .before_request(&mut request_parts(Request::builder()), now)
@@ -63,6 +64,7 @@ fn test_when_methods_match() {
     let policy = CachePolicy::try_new(
         &request_parts(Request::builder().method(Method::GET)),
         response,
+        now,
     ).unwrap();
 
     assert!(policy
@@ -81,6 +83,7 @@ fn must_revalidate_allows_not_revalidating_fresh() {
     let policy = CachePolicy::try_new(
         &request_parts(Request::builder().method(Method::GET)),
         response,
+        now,
     ).unwrap();
 
     assert!(policy
@@ -107,6 +110,7 @@ fn must_revalidate_disallows_stale() {
     let policy = CachePolicy::try_new(
         &request_parts(Request::builder().method(Method::GET)),
         response,
+        now,
     ).unwrap();
 
     let later = now + std::time::Duration::from_secs(300);
@@ -141,6 +145,7 @@ fn test_not_when_hosts_mismatch() {
     let policy = CachePolicy::try_new(
         &request_parts(Request::builder().header(header::HOST, "foo")),
         response,
+        now,
     ).unwrap();
 
     assert!(policy
@@ -169,6 +174,7 @@ fn test_when_methods_match_head() {
     let policy = CachePolicy::try_new(
         &request_parts(Request::builder().method(Method::HEAD)),
         response,
+        now,
     ).unwrap();
 
     assert!(policy
@@ -184,7 +190,8 @@ fn test_not_when_proxy_revalidating() {
             .status(200)
             .header(header::CACHE_CONTROL, "max-age=2, proxy-revalidate "),
     );
-    let policy = CachePolicy::try_new(&request_parts(Request::builder()), response).unwrap();
+    let policy =
+        CachePolicy::try_new(&request_parts(Request::builder()), response, now).unwrap();
 
     assert!(!policy
         .before_request(&mut request_parts(Request::builder()), now)
@@ -218,7 +225,7 @@ fn test_when_not_a_proxy_revalidating() {
 fn test_not_when_no_cache_requesting() {
     let now = SystemTime::now();
     let response = &response_parts(Response::builder().header(header::CACHE_CONTROL, "max-age=2"));
-    let policy = CachePolicy::try_new(&request_parts(Request::builder()), response).unwrap();
+    let policy = CachePolicy::try_new(&request_parts(Request::builder()), response, now).unwrap();
 
     assert!(policy
         .before_request(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -337,6 +337,7 @@ fn test_do_not_cache_partial_response() {
                 "cache-control": "max-age=60",
             }
         })),
+        SystemTime::now(),
     ).unwrap_err();
 }
 
@@ -363,6 +364,7 @@ fn test_no_store_kills_cache() {
                 "cache-control": "public, max-age=222",
             }
         })),
+        now,
     ).unwrap_err().0;
 
     assert!(policy.is_stale(now));
@@ -381,6 +383,7 @@ fn test_post_not_cacheable_by_default() {
                 "cache-control": "public",
             }
         })),
+        now,
     ).unwrap_err().0;
 
     assert!(policy.is_stale(now));
@@ -399,6 +402,7 @@ fn test_post_cacheable_explicitly() {
                 "cache-control": "public, max-age=222",
             }
         })),
+        now,
     ).unwrap();
 
     assert_eq!(policy.is_stale(now), false);
@@ -419,6 +423,7 @@ fn test_public_cacheable_auth_is_ok() {
                 "cache-control": "public, max-age=222",
             }
         })),
+        now,
     ).unwrap();
 
     assert_eq!(policy.is_stale(now), false);
@@ -439,6 +444,7 @@ fn test_proxy_cacheable_auth_is_ok() {
                 "cache-control": "max-age=0,s-maxage=12",
             }
         })),
+        now,
     ).unwrap();
 
     assert_eq!(policy.is_stale(now), false);
@@ -491,6 +497,7 @@ fn test_revalidate_auth_is_ok() {
                 "cache-control": "max-age=88,must-revalidate",
             }
         })),
+        SystemTime::now(),
     ).unwrap();
 }
 
@@ -509,6 +516,7 @@ fn test_auth_prevents_caching_by_default() {
                 "cache-control": "max-age=111",
             }
         })),
+        now,
     ).unwrap_err().0;
 
     assert!(policy.is_stale(now));
@@ -523,6 +531,7 @@ fn test_simple_miss() {
             "headers": {},
         })),
         &res(json!({})),
+        now,
     ).unwrap();
 
     assert!(policy.is_stale(now));
@@ -540,6 +549,7 @@ fn test_simple_hit() {
             "cache-control": "public, max-age=999999"
         }
         })),
+        now,
     ).unwrap();
 
     assert_eq!(policy.is_stale(now), false);
@@ -558,6 +568,7 @@ fn test_weird_syntax() {
             "cache-control": ",,,,max-age =  456      ,"
         }
         })),
+        now,
     ).unwrap();
 
     assert_eq!(policy.is_stale(now), false);
@@ -585,6 +596,7 @@ fn test_quoted_syntax() {
             "cache-control": "  max-age = \"678\"      "
         }
         })),
+        now,
     ).unwrap();
 
     assert_eq!(policy.is_stale(now), false);
@@ -605,6 +617,7 @@ fn test_age_can_make_stale() {
                 "age": "101"
             }
         })),
+        now,
     ).unwrap();
 
     assert!(policy.is_stale(now));
@@ -624,6 +637,7 @@ fn test_age_not_always_stale() {
                 "age": "15"
             }
         })),
+        now,
     ).unwrap();
 
     assert_eq!(policy.is_stale(now), false);
@@ -643,6 +657,7 @@ fn test_bogus_age_ignored() {
                 "age": "golden"
             }
         })),
+        now,
     ).unwrap();
 
     assert_eq!(policy.is_stale(now), false);
@@ -661,6 +676,7 @@ fn test_immutable_simple_hit() {
                 "cache-control": "immutable, max-age=999999",
             }
         })),
+        now,
     ).unwrap();
 
     assert_eq!(policy.is_stale(now), false);
@@ -680,6 +696,7 @@ fn test_immutable_can_expire() {
                 "cache-control": "immutable, max-age=0",
             }
         })),
+        now,
     ).unwrap();
 
     assert!(policy.is_stale(now));
@@ -700,6 +717,7 @@ fn test_pragma_no_cache() {
                 "last-modified": "Mon, 07 Mar 2016 11:52:56 GMT",
             }
         })),
+        now,
     ).unwrap();
 
     assert!(policy.is_stale(now));
@@ -718,6 +736,7 @@ fn test_no_store() {
                 "cache-control": "no-store, public, max-age=1",
             }
         })),
+        now,
     ).unwrap_err().0;
 
     assert!(policy.is_stale(now));
@@ -737,6 +756,7 @@ fn test_observe_private_cache() {
             "headers": {},
         })),
         &res(json!({ "headers": private_header })),
+        now,
     ).unwrap_err().0;
 
     assert!(proxy_policy.is_stale(now));
@@ -861,6 +881,7 @@ fn test_miss_max_age_equals_zero() {
                 "cache-control": "public, max-age=0",
             },
         })),
+        now,
     ).unwrap();
 
     assert!(policy.is_stale(now));
@@ -881,6 +902,7 @@ fn test_uncacheable_503() {
                 "cache-control": "public, max-age=0",
             },
         })),
+        now,
     ).unwrap_err().0;
 
     assert!(policy.is_stale(now));
@@ -901,6 +923,7 @@ fn test_cacheable_301() {
                 "last-modified": "Mon, 07 Mar 2016 11:52:56 GMT",
             },
         })),
+        now,
     ).unwrap();
 
     assert_eq!(policy.is_stale(now), false);
@@ -920,6 +943,7 @@ fn test_uncacheable_303() {
                 "last-modified": "Mon, 07 Mar 2016 11:52:56 GMT",
             },
         })),
+        now,
     ).unwrap_err().0;
 
     assert!(policy.is_stale(now));
@@ -940,6 +964,7 @@ fn test_cacheable_303() {
                 "cache-control": "max-age=1000",
             },
         })),
+        now,
     ).unwrap();
 
     assert_eq!(policy.is_stale(now), false);
@@ -959,6 +984,7 @@ fn test_uncacheable_412() {
                 "cache-control": "public, max-age=1000",
             },
         })),
+        now,
     ).unwrap_err().0;
 
     assert!(policy.is_stale(now));
@@ -979,6 +1005,7 @@ fn test_expired_expires_cache_with_max_age() {
                 "expires": "Sat, 07 May 2016 15:35:18 GMT",
             },
         })),
+        now,
     ).unwrap();
 
     assert_eq!(policy.is_stale(now), false);
@@ -1001,6 +1028,7 @@ fn test_expired_expires_cached_with_s_maxage() {
         &res(json!({
             "headers": s_max_age_headers,
         })),
+        now,
     ).unwrap();
 
     assert_eq!(proxy_policy.is_stale(now), false);
@@ -1038,6 +1066,7 @@ fn test_when_urls_match() {
                 "cache-control": "max-age=2",
             },
         })),
+        now,
     ).unwrap();
 
     assert!(policy
@@ -1065,6 +1094,7 @@ fn test_not_when_urls_mismatch() {
                 "cache-control": "max-age=2",
             },
         })),
+        now,
     ).unwrap();
 
     assert!(!policy
@@ -1092,6 +1122,7 @@ fn test_when_methods_match() {
                 "cache-control": "max-age=2",
             },
         })),
+        now,
     ).unwrap();
 
     assert!(
@@ -1123,6 +1154,7 @@ fn test_not_when_hosts_mismatch() {
                 "cache-control": "max-age=2",
             },
         })),
+        now,
     ).unwrap();
 
     assert!(policy
@@ -1162,6 +1194,7 @@ fn test_when_methods_match_head() {
                 "cache-control": "max-age=2",
             },
         })),
+        now,
     ).unwrap();
 
     assert!(policy
@@ -1189,6 +1222,7 @@ fn test_not_when_methods_mismatch() {
                 "cache-control": "max-age=2",
             },
         })),
+        now,
     ).unwrap();
 
     assert!(!policy
@@ -1216,6 +1250,7 @@ fn test_not_when_methods_mismatch_head() {
                 "cache-control": "max-age=2",
             },
         })),
+        now,
     ).unwrap();
 
     assert_eq!(
@@ -1245,6 +1280,7 @@ fn test_not_when_proxy_revalidating() {
                 "cache-control": "max-age=2, proxy-revalidate ",
             },
         })),
+        now,
     ).unwrap();
 
     assert!(!policy
@@ -1359,6 +1395,7 @@ fn test_vary_basic() {
                 "vary": "weather",
             },
         })),
+        now,
     ).unwrap();
 
     assert!(policy
@@ -1402,6 +1439,7 @@ fn test_asterisks_does_not_match() {
                 "vary": "*",
             },
         })),
+        now,
     ).unwrap();
 
     assert_eq!(
@@ -1434,6 +1472,7 @@ fn test_asterisks_is_stale() {
                 "vary": "*",
             },
         })),
+        now,
     ).unwrap();
 
     let policy_two = CachePolicy::try_new(
@@ -1448,6 +1487,7 @@ fn test_asterisks_is_stale() {
                 "vary": "weather",
             },
         })),
+        now,
     ).unwrap();
 
     assert!(policy_one.is_stale(now));
@@ -1469,6 +1509,7 @@ fn test_values_are_case_sensitive() {
                 "vary": "Weather",
             },
         })),
+        now,
     ).unwrap();
 
     assert!(policy
@@ -1512,6 +1553,7 @@ fn test_irrelevant_headers_ignored() {
                 "vary": "moon-phase",
             },
         })),
+        now,
     ).unwrap();
 
     assert!(policy
@@ -1566,6 +1608,7 @@ fn test_absence_is_meaningful() {
                 "vary": "moon-phase, weather",
             },
         })),
+        now,
     ).unwrap();
 
     assert!(policy
@@ -1623,6 +1666,7 @@ fn test_all_values_must_match() {
                 "vary": "weather, sun",
             },
         })),
+        now,
     ).unwrap();
 
     assert!(policy
@@ -1669,6 +1713,7 @@ fn test_whitespace_is_okay() {
                 "vary": "    weather       ,     sun     ",
             },
         })),
+        now,
     ).unwrap();
 
     assert!(policy
@@ -1728,6 +1773,7 @@ fn test_order_is_irrelevant() {
                 "vary": "weather, sun",
             },
         })),
+        now,
     ).unwrap();
 
     let policy_two = CachePolicy::try_new(
@@ -1743,6 +1789,7 @@ fn test_order_is_irrelevant() {
                 "vary": "sun, weather",
             },
         })),
+        now,
     ).unwrap();
 
     assert!(policy_one

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -63,6 +63,7 @@ fn not_modified_response_headers_for_update(
     let policy = CachePolicy::try_new(
         &request_parts(first_request_builder),
         &response_parts(first_response_builder),
+        now,
     ).unwrap();
 
     let headers = get_revalidation_request(

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -60,10 +60,10 @@ fn not_modified_response_headers_for_update(
     second_response_builder: http::response::Builder,
 ) -> Option<HeaderMap> {
     let now = SystemTime::now();
-    let policy = CachePolicy::new(
+    let policy = CachePolicy::try_new(
         &request_parts(first_request_builder),
         &response_parts(first_response_builder),
-    );
+    ).unwrap();
 
     let headers = get_revalidation_request(
         &policy,

--- a/tests/vary.rs
+++ b/tests/vary.rs
@@ -20,10 +20,10 @@ fn test_vary_basic() {
             .header(header::VARY, "weather"),
     );
 
-    let policy = CachePolicy::new(
+    let policy = CachePolicy::try_new(
         &request_parts(Request::builder().header("weather", "nice")),
         &response,
-    );
+    ).unwrap();
 
     assert!(policy
         .before_request(
@@ -49,10 +49,10 @@ fn test_asterisks_does_not_match() {
             .header(header::VARY, "*"),
     );
 
-    let policy = CachePolicy::new(
+    let policy = CachePolicy::try_new(
         &request_parts(Request::builder().header("weather", "ok")),
         &response,
-    );
+    ).unwrap();
 
     assert!(!policy
         .before_request(
@@ -65,23 +65,23 @@ fn test_asterisks_does_not_match() {
 #[test]
 fn test_asterisks_is_stale() {
     let now = SystemTime::now();
-    let policy_one = CachePolicy::new(
+    let policy_one = CachePolicy::try_new(
         &request_parts(Request::builder().header("weather", "ok")),
         &response_parts(
             Response::builder()
                 .header(header::CACHE_CONTROL, "public,max-age=99")
                 .header(header::VARY, "*"),
         ),
-    );
+    ).unwrap();
 
-    let policy_two = CachePolicy::new(
+    let policy_two = CachePolicy::try_new(
         &request_parts(Request::builder().header("weather", "ok")),
         &response_parts(
             Response::builder()
                 .header(header::CACHE_CONTROL, "public,max-age=99")
                 .header(header::VARY, "weather"),
         ),
-    );
+    ).unwrap();
 
     assert!(policy_one.is_stale(now));
     assert!(!policy_two.is_stale(now));
@@ -96,10 +96,10 @@ fn test_values_are_case_sensitive() {
             .header(header::VARY, "weather"),
     );
 
-    let policy = CachePolicy::new(
+    let policy = CachePolicy::try_new(
         &request_parts(Request::builder().header("weather", "BAD")),
         &response,
-    );
+    ).unwrap();
 
     assert!(policy
         .before_request(
@@ -125,10 +125,10 @@ fn test_irrelevant_headers_ignored() {
             .header(header::VARY, "moon-phase"),
     );
 
-    let policy = CachePolicy::new(
+    let policy = CachePolicy::try_new(
         &request_parts(Request::builder().header("weather", "nice")),
         &response,
-    );
+    ).unwrap();
 
     assert!(policy
         .before_request(
@@ -161,10 +161,10 @@ fn test_absence_is_meaningful() {
             .header(header::VARY, "moon-phase, weather"),
     );
 
-    let policy = CachePolicy::new(
+    let policy = CachePolicy::try_new(
         &request_parts(Request::builder().header("weather", "nice")),
         &response,
-    );
+    ).unwrap();
 
     assert!(policy
         .before_request(
@@ -198,14 +198,14 @@ fn test_all_values_must_match() {
             .header(header::VARY, "weather, sun"),
     );
 
-    let policy = CachePolicy::new(
+    let policy = CachePolicy::try_new(
         &request_parts(
             Request::builder()
                 .header("sun", "shining")
                 .header("weather", "nice"),
         ),
         &response,
-    );
+    ).unwrap();
 
     assert!(policy
         .before_request(
@@ -239,14 +239,14 @@ fn test_whitespace_is_okay() {
             .header(header::VARY, "    weather       ,     sun     "),
     );
 
-    let policy = CachePolicy::new(
+    let policy = CachePolicy::try_new(
         &request_parts(
             Request::builder()
                 .header("sun", "shining")
                 .header("weather", "nice"),
         ),
         &response,
-    );
+    ).unwrap();
 
     assert!(policy
         .before_request(
@@ -289,23 +289,23 @@ fn test_order_is_irrelevant() {
             .header(header::VARY, "sun, weather"),
     );
 
-    let policy_one = CachePolicy::new(
+    let policy_one = CachePolicy::try_new(
         &request_parts(
             Request::builder()
                 .header("sun", "shining")
                 .header("weather", "nice"),
         ),
         &response_one,
-    );
+    ).unwrap();
 
-    let policy_two = CachePolicy::new(
+    let policy_two = CachePolicy::try_new(
         &request_parts(
             Request::builder()
                 .header("sun", "shining")
                 .header("weather", "nice"),
         ),
         &response_two,
-    );
+    ).unwrap();
 
     assert!(policy_one
         .before_request(

--- a/tests/vary.rs
+++ b/tests/vary.rs
@@ -23,6 +23,7 @@ fn test_vary_basic() {
     let policy = CachePolicy::try_new(
         &request_parts(Request::builder().header("weather", "nice")),
         &response,
+        now,
     ).unwrap();
 
     assert!(policy
@@ -52,6 +53,7 @@ fn test_asterisks_does_not_match() {
     let policy = CachePolicy::try_new(
         &request_parts(Request::builder().header("weather", "ok")),
         &response,
+        now,
     ).unwrap();
 
     assert!(!policy
@@ -72,6 +74,7 @@ fn test_asterisks_is_stale() {
                 .header(header::CACHE_CONTROL, "public,max-age=99")
                 .header(header::VARY, "*"),
         ),
+        now,
     ).unwrap();
 
     let policy_two = CachePolicy::try_new(
@@ -81,6 +84,7 @@ fn test_asterisks_is_stale() {
                 .header(header::CACHE_CONTROL, "public,max-age=99")
                 .header(header::VARY, "weather"),
         ),
+        now,
     ).unwrap();
 
     assert!(policy_one.is_stale(now));
@@ -99,6 +103,7 @@ fn test_values_are_case_sensitive() {
     let policy = CachePolicy::try_new(
         &request_parts(Request::builder().header("weather", "BAD")),
         &response,
+        now,
     ).unwrap();
 
     assert!(policy
@@ -128,6 +133,7 @@ fn test_irrelevant_headers_ignored() {
     let policy = CachePolicy::try_new(
         &request_parts(Request::builder().header("weather", "nice")),
         &response,
+        now,
     ).unwrap();
 
     assert!(policy
@@ -164,6 +170,7 @@ fn test_absence_is_meaningful() {
     let policy = CachePolicy::try_new(
         &request_parts(Request::builder().header("weather", "nice")),
         &response,
+        now,
     ).unwrap();
 
     assert!(policy
@@ -205,6 +212,7 @@ fn test_all_values_must_match() {
                 .header("weather", "nice"),
         ),
         &response,
+        now,
     ).unwrap();
 
     assert!(policy
@@ -246,6 +254,7 @@ fn test_whitespace_is_okay() {
                 .header("weather", "nice"),
         ),
         &response,
+        now,
     ).unwrap();
 
     assert!(policy
@@ -296,6 +305,7 @@ fn test_order_is_irrelevant() {
                 .header("weather", "nice"),
         ),
         &response_one,
+        now,
     ).unwrap();
 
     let policy_two = CachePolicy::try_new(
@@ -305,6 +315,7 @@ fn test_order_is_irrelevant() {
                 .header("weather", "nice"),
         ),
         &response_two,
+        now,
     ).unwrap();
 
     assert!(policy_one


### PR DESCRIPTION
Changes the constructors to return `Result<CachePolicy, NotStorable>` where `NotStorable` is a wrapper that indicates the inner `CachePolicy` MUST NOT be stored, along with changing the base constructor to take an explicit time instead of internally calling `SystemTime::now()`. Both of these changes were handled through adding new constructors and deprecating the old ones

_old_

```rust
impl CachePolicy {
    pub fn new(&Req, &Res) -> Self { ... }
    pub fn new_options(&Req, &Res, SystemTime, CacheOptions) -> Self { ... }
}
```

_new_

```rust
impl CachePolicy {
    pub fn try_new(&Req, &Res, SystemTime) -> Result<Self, NotStorable> { ... }
    pub fn try_new_with_options(&Req, &Res, SystemTime, CacheOptions) -> Result<Self, NotStorable> { ... }
}
```

closes #13 closes #14