### PR TITLE
Fix usage of the `last-modified` header in `after_response()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -693,8 +693,8 @@ impl CachePolicy {
         let response_headers = response.headers();
         let mut response_status = response.status();
 
-        let old_etag = &self.res.get_str("etag").map(str::trim);
-        let old_last_modified = response_headers.get_str("last-modified").map(str::trim);
+        let old_etag = self.res.get_str("etag").map(str::trim);
+        let old_last_modified = self.res.get_str("last-modified").map(str::trim);
         let new_etag = response_headers.get_str("etag").map(str::trim);
         let new_last_modified = response_headers.get_str("last-modified").map(str::trim);
 


### PR DESCRIPTION
`old_last_modified` was incorrectly retrieved from the new response headers instead of the old ones, making `old_last_modified` always equal to `new_last_modified`.

Fix this by getting it from `self.res` instead of `response_headers`.